### PR TITLE
Dependencies fix + httpx/core logging gag

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -23,6 +23,11 @@ from torchvision import transforms
 from gradio_imageslider import ImageSlider
 from loadimg import load_img  # Image loading utility
 
+# change httx/httpcore default from INFO to stop its startup log interferring with URL capture
+import logging
+logging.getLogger('httpx').setLevel(logging.WARNING)
+logging.getLogger('httpcore').setLevel(logging.WARNING)  
+
 # ML/AI framework imports
 from transformers import AutoModelForImageSegmentation  # Hugging Face model for background removal
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -7,7 +7,7 @@ kornia
 prettytable
 typing
 scikit-image
-transformers>=4.39.1
-gradio==5.23.2
+transformers>=4.39.1,<4.50.0
+gradio==4.44.0
 gradio_imageslider==0.0.20
 loadimg>=0.1.1

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -8,6 +8,6 @@ prettytable
 typing
 scikit-image
 transformers>=4.39.1,<4.50.0
-gradio==4.44.0
+gradio==4.44.0  #pinned for imageslider which isn't yet compatible with gradio 5
 gradio_imageslider==0.0.20
 loadimg>=0.1.1

--- a/install.js
+++ b/install.js
@@ -15,8 +15,10 @@ module.exports = {
       params: {
         venv: "env",               
         path: "app",
-        message:"uv pip install -r requirements.txt",
-                "uv pip install pydantic==2.10.6",
+        message:[
+        "uv pip install -r requirements.txt",
+        "uv pip install pydantic==2.10.6",
+        ]
       }
     },
   ]

--- a/install.js
+++ b/install.js
@@ -16,6 +16,7 @@ module.exports = {
         venv: "env",               
         path: "app",
         message:"uv pip install -r requirements.txt",
+                "uv pip install pydantic==2.10.6",
       }
     },
   ]


### PR DESCRIPTION
* Reverted `gradio` back to 4 for `ImageSlider` compatibility. 
* pinned `pydantic` in `install.js` 
* pinned `transformers` to avoid breaking changes in 4.5.0

Changed the httpx/httpcore logging default level in `app.py` to prevent it from displaying INFO log on startup. This was interfering with the URL regex capture. No idea why this INFO display started recently.

Tested locally and all works again. 